### PR TITLE
add Integration test

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,0 +1,37 @@
+# About
+
+The scripts in this folder perform integration tests with an generated Julia package ecosystem.
+
+Therefore, the `create_package_eco_system()` function in `prepareIntegrationTest.jl` creates various Julia packages and sets the dependencies. The following diagram shows the created package ecosystem.
+
+```mermaid
+graph TD
+   MyPkgMeta(MyPkgMeta) --> MyPkgA(MyPkgA)
+   MyPkgA --> MyPkgE(MyPkgE)
+   MyPkgA --> MyPkgB(MyPkgB) --> MyPkgE
+   MyPkgA --> MyPkgC(MyPkgC) --> MyPkgE
+   MyPkgB --> MyPkgC
+   MyPkgA --> MyPkgD(MyPkgD) --> MyPkgE
+
+   MyPkgE --> JSON(JSON)
+   MyPkgE --> Pkg(Pkg)
+   MyPkgE --> Test(Test)
+
+   MyPkgC --> JSON
+
+   MyPkgB --> PkgTemplate(PkgTemplate)
+
+   MyPkgA --> JSON
+```
+
+All packages starting with `MyPkg` are locally created packages. The other packages are third-party dependencies on existing packages from the Julia Registry.
+
+The `MyPkgMeta` is a specially created package. It is not part of the normal package ecosystem and is only needed to generate the correct list of dependencies. For more details, read the the [Integration Test Tool documentation](https://qedjl-project.github.io/IntegrationTests.jl/dev/integration_test_tool/). `MyPkgMeta` has only one dependency, namely the package `MyPkgA`. The `MyPkgA` itself has all other packages as direct dependencies. We use the environment of the `MyPkgMeta` package to construct the dependency tree for the `depending_projects()` function. We cannot use `MyPkgA` directly because a package is not a member of its own dependency graph. This means that `depending_projects()` would not check if `MyPkgA` is a dependency of the package we are looking for, as it is not part of the dependency graph.
+
+# Test scripts
+
+All test scripts use the same example ecosystem but the scripts perform different types of tests:
+
+- `getDeps.jl`: Calls the function `depending_projects()` and compares the generated list of package names with a list of expected package names.
+- `generateGithubActions.jl`: Calls the `depending_projects()` function, takes the generated list of package names and print it. Then GitHub Action create and execute a CI job for each entry.
+Then creates a GitHub action request for each package name.

--- a/.ci/generateGithubActions.jl
+++ b/.ci/generateGithubActions.jl
@@ -1,0 +1,21 @@
+module getDeps
+
+using IntegrationTests
+using Pkg
+using PkgDependency
+
+include(joinpath(dirname(@__FILE__), "prepareIntegrationTest.jl"))
+
+# see README.md
+if !isinteractive()
+    tmp_path = mktempdir()
+    prepareIntegrationTest.create_package_eco_system(tmp_path)
+
+    # extra Project.toml to generate dependency graph for the whole project
+    Pkg.activate(joinpath(tmp_path, "MyPkgMeta"))
+    depending_packages = IntegrationTests.depending_projects("MyPkgC", r"^MyPkg*")
+
+    print(depending_packages)
+end
+
+end

--- a/.ci/getDeps.jl
+++ b/.ci/getDeps.jl
@@ -1,0 +1,23 @@
+module getDeps
+
+using IntegrationTests
+using Pkg
+using PkgDependency
+
+include(joinpath(dirname(@__FILE__), "prepareIntegrationTest.jl"))
+
+# see README.md
+if !isinteractive()
+    tmp_path = mktempdir()
+    prepareIntegrationTest.create_package_eco_system(tmp_path)
+
+    # extra Project.toml to generate dependency graph for the whole project
+    Pkg.activate(joinpath(tmp_path, "MyPkgMeta"))
+    depending_packages = IntegrationTests.depending_projects("MyPkgC", r"^MyPkg*")
+
+    # compare with expected result
+    # needs to be negated, because true would result in error code 1
+    exit(!(sort(depending_packages) == sort(["MyPkgA", "MyPkgB"])))
+end
+
+end

--- a/.ci/prepareIntegrationTest.jl
+++ b/.ci/prepareIntegrationTest.jl
@@ -1,0 +1,57 @@
+module prepareIntegrationTest
+
+using Pkg
+
+"""
+    create_package_eco_system(base_path)
+
+Creates a Julia package ecosystem in the `base_path` folder for testing purposes.
+
+# Arguments
+
+- `base_path`: Path to folder where ecosystem is created.
+
+"""
+function create_package_eco_system(base_path)
+    # A graphical representation of the dependencies between the packages can be found in the 
+    # README.md.
+
+    cd(base_path)
+    Pkg.generate("MyPkgA")
+    Pkg.generate("MyPkgB")
+    Pkg.generate("MyPkgC")
+    Pkg.generate("MyPkgD")
+    Pkg.generate("MyPkgE")
+    Pkg.generate("MyPkgMeta")
+
+    Pkg.activate("MyPkgE")
+    Pkg.add("JSON")
+    Pkg.add("Pkg")
+    Pkg.add("Test")
+
+    Pkg.activate("MyPkgD")
+    Pkg.develop(; path=joinpath(base_path, "MyPkgE"))
+
+    Pkg.activate("MyPkgC")
+    Pkg.add("JSON")
+    Pkg.develop(; path=joinpath(base_path, "MyPkgE"))
+
+    Pkg.activate("MyPkgB")
+    Pkg.develop(; path=joinpath(base_path, "MyPkgE"))
+    Pkg.develop(; path=joinpath(base_path, "MyPkgC"))
+    Pkg.add("PkgTemplates")
+
+    Pkg.activate("MyPkgA")
+    Pkg.develop(; path=joinpath(base_path, "MyPkgE"))
+    Pkg.develop(; path=joinpath(base_path, "MyPkgD"))
+    Pkg.develop(; path=joinpath(base_path, "MyPkgC"))
+    Pkg.develop(; path=joinpath(base_path, "MyPkgB"))
+    Pkg.add("YAML")
+
+    Pkg.activate("MyPkgMeta")
+    Pkg.develop(; path=joinpath(base_path, "MyPkgA"))
+
+    return Nothing
+end
+
+end

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -1,0 +1,66 @@
+name: IntegrationTest
+on:
+  push:
+    branches:
+      - main
+      - dev
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.6'
+          - '1.7'
+          - '1.8'
+          - '1.9'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Run integration test script
+        run: julia --project=${GITHUB_WORKSPACE} .ci/getDeps.jl
+  
+  generate:
+    name: Github Action - Generator Integration Jobs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1.9
+          arch: x64
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - id: set-matrix
+        run: echo "matrix=$(julia --project=${GITHUB_WORKSPACE} .ci/generateGithubActions.jl 2> /dev/null)" >> $GITHUB_OUTPUT
+    outputs:
+        matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+  run-matrix:
+    needs: generate
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            package: ${{ fromJson(needs.generate.outputs.matrix) }}
+    steps:
+        - run: echo "run Integration Test for package ${{ matrix.package }}"


### PR DESCRIPTION
The integration test takes julia package eco system and search for all depended jobs of a specific package.

A seconds test takes the results of the integration test and generates new GitHub Actions Jobs like a project which uses `IntegrationTests.jl`.