### PR TITLE
remove unit test with julia nightly 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,6 @@ jobs:
           - '1.8'
           - '1.9'
           - '1.10'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/integrationTests.yml
+++ b/.github/workflows/integrationTests.yml
@@ -25,7 +25,6 @@ jobs:
           - '1.8'
           - '1.9'
           - '1.10'
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
There is no good way to handle the failing nightly test. Therefore remove it to reduce maintenance costs.